### PR TITLE
fix: add 'latta' import alias to match official docs

### DIFF
--- a/latta_python_recorder/__init__.py
+++ b/latta_python_recorder/__init__.py
@@ -2,3 +2,7 @@ from .latta import Latta
 
 # Expose Latta directly for easy import
 __all__ = ["Latta"]
+
+# Alias for official docs compatibility
+import sys
+sys.modules['latta'] = sys.modules[__name__]


### PR DESCRIPTION
The official docs suggest importing the recorder with:

```python
from latta import Latta
```
However, the PyPI package is latta-python-recorder, so users currently must do:
```python
from latta_python_recorder import Latta
```
This PR adds a latta alias in __init__.py to match the docs:
```python
import sys
sys.modules['latta'] = sys.modules[__name__]
```
